### PR TITLE
Modifying nightly test scripts to (hopefully) push to new SRN CDash site

### DIFF
--- a/doc/LCM/build/CTestConfig.cmake
+++ b/doc/LCM/build/CTestConfig.cmake
@@ -1,9 +1,10 @@
 
-set(CTEST_PROJECT_NAME "Albany_LCM")
+set(CTEST_PROJECT_NAME "Albany-LCM")
 set(CTEST_NIGHTLY_START_TIME "01:00:00 UTC")
 
 set(CTEST_DROP_METHOD "https")
-set(CTEST_DROP_SITE "sems-cdash-son.sandia.gov")
-set(CTEST_DROP_LOCATION "/cdash/submit.php?project=Albany_LCM")
+set(CTEST_DROP_SITE "albany-lcm-cdash.sandia.gov")
+set(CTEST_DROP_LOCATION "submit.php?project=Albany-LCM")
 set(CTEST_DROP_SITE_CDASH TRUE)
+
 

--- a/doc/LCM/build/lcm_build.cmake
+++ b/doc/LCM/build/lcm_build.cmake
@@ -8,7 +8,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/lcm_do_package.cmake")
 
 set(CTEST_TEST_TYPE Nightly)
 set(CTEST_CMAKE_GENERATOR  "Unix Makefiles")
-set(CTEST_PROJECT_NAME "Albany_LCM")
+set(CTEST_PROJECT_NAME "Albany-LCM")
 set (CTEST_COMMAND "ctest -D ${CTEST_TEST_TYPE}")
 
 message("SCRIPT_NAME ${SCRIPT_NAME}")


### PR DESCRIPTION
@lxmota , you will need to modify the nightly test scripts on Rigel to have these modifications.  I can then check if it worked.  The new CDash site can be found here: https://albany-lcm-cdash.sandia.gov/index.php?project=Albany-LCM (are you able to see/access it?  If not, I may have to ask them to give you access.).